### PR TITLE
🚀 Enhance TeslaACDC: New Controllers, Services & Repository for Albums and Artists

### DIFF
--- a/TeslaACDC.API/Controllers/AlbumController.cs
+++ b/TeslaACDC.API/Controllers/AlbumController.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using TeslaACDC.Business.Interfaces;
+using TeslaACDC.Data.Models;
 
 namespace TeslaACDC.API.Controllers
 {
@@ -61,6 +62,13 @@ namespace TeslaACDC.API.Controllers
         {
             var result = await _albumService.FindByYear(Year);
             return result.StatusCode == HttpStatusCode.OK ? Ok(result) : StatusCode((int)result.StatusCode, result);
+        }
+
+        [HttpPost("addAlbum")]
+        public async Task<IActionResult> AddAlbum(Album album)
+        {
+            var result = await _albumService.AddAlbum(album);
+            return result.StatusCode == HttpStatusCode.Created ? Ok(result) : StatusCode((int)result.StatusCode, result);
         }
 
     }

--- a/TeslaACDC.API/Controllers/ArtistController.cs
+++ b/TeslaACDC.API/Controllers/ArtistController.cs
@@ -1,0 +1,43 @@
+namespace TeslaACDC.API.Controllers;
+
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using TeslaACDC.Business.Interfaces;
+using TeslaACDC.Data.Models;
+
+[Route("api/[controller]")]
+[ApiController]
+public class ArtistController(IArtistService artistService) : ControllerBase
+{
+    private readonly IArtistService _artistService = artistService;
+
+    [HttpGet("getArtist/{id}")]
+    public async Task<IActionResult> GetArtist(int id)
+    {
+        var artist = await _artistService.FindById(id);
+        return StatusCode((int)artist.StatusCode, artist);
+    }
+
+    [HttpGet("getAllArtists")]
+    public async Task<IActionResult> GetAllArtists()
+    {
+        var artists = await _artistService.GetAll();
+        return StatusCode((int)artists.StatusCode, artists);
+    }
+
+    [HttpPost("updateArtist")]
+    public async Task<IActionResult> UpdateArtist(Artist artist)
+    {
+        var updatedArtistStatus = await _artistService.Update(artist);
+        return StatusCode((int)updatedArtistStatus.StatusCode, updatedArtistStatus);
+    }
+
+    [HttpPost("addArtist")]
+    public async Task<IActionResult> AddArtist(Artist artist)
+    {
+        var addedArtist = await _artistService.Add(artist);
+        return StatusCode((int)addedArtist.StatusCode, addedArtist);
+    }
+
+}
+

--- a/TeslaACDC.API/Program.cs
+++ b/TeslaACDC.API/Program.cs
@@ -2,6 +2,9 @@ using Microsoft.EntityFrameworkCore;
 using TeslaACDC.Business.Interfaces;
 using TeslaACDC.Business.Services;
 using TeslaACDC.Data;
+using TeslaACDC.Data.Interfaces;
+using TeslaACDC.Data.Models;
+using TeslaACDC.Data.Repository;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +23,10 @@ builder.Services.AddDbContext<DatabaseContext>(
 // Inyeccion de dependencias
 builder.Services.AddScoped<IAlbumService, AlbumService>();
 builder.Services.AddScoped<IMatematikaService, MatematikaService>();
+builder.Services.AddScoped<IArtistService, ArtistService>();
+builder.Services.AddScoped<IAlbumRepository<int, Album>, AlbumRepository<int, Album>>();
+builder.Services.AddScoped<IArtistRepository<int, Artist>, ArtistRepository<int, Artist>>();
+
 
 var app = builder.Build();
 

--- a/TeslaACDC.API/TeslaACDC.API.csproj
+++ b/TeslaACDC.API/TeslaACDC.API.csproj
@@ -18,6 +18,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeslaACDC.Business/Interfaces/IAlbumService.cs
+++ b/TeslaACDC.Business/Interfaces/IAlbumService.cs
@@ -5,8 +5,8 @@ namespace TeslaACDC.Business.Interfaces;
 public interface IAlbumService
 {
     Task<BaseMessage<List<Album>>> GetList();
-    Task<List<Album>> AddAlbum();
-    Task<BaseMessage<List<Album>>> FindById(int Id);
+    Task<BaseMessage<Album>> AddAlbum(Album album);
+    Task<BaseMessage<Album>> FindById(int Id);
     Task<BaseMessage<List<Album>>> FindByName(string Name);
     Task<BaseMessage<List<Album>>> FindByYear(int Year);
     Task<BaseMessage<List<Album>>> FindByRangeOfYear(int StartYear, int EndYear);

--- a/TeslaACDC.Business/Interfaces/IArtistService.cs
+++ b/TeslaACDC.Business/Interfaces/IArtistService.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using TeslaACDC.Data.Models;
+
+namespace TeslaACDC.Business.Interfaces;
+
+public interface IArtistService
+{
+    public Task<BaseMessage<Artist>> FindById(int id);
+    public Task<BaseMessage<Artist>> Add(Artist artist);
+    public Task<BaseMessage<List<Artist>>> GetAll();
+    public Task<BaseMessage<Artist>> Update(Artist artist);
+
+}

--- a/TeslaACDC.Business/Services/AlbumService.cs
+++ b/TeslaACDC.Business/Services/AlbumService.cs
@@ -1,150 +1,119 @@
 using System.Net;
-using System.Text;
 using TeslaACDC.Business.Interfaces;
+using TeslaACDC.Data.Interfaces;
 using TeslaACDC.Data.Models;
+
 
 namespace TeslaACDC.Business.Services;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
-public class AlbumService : IAlbumService
+public class AlbumService(IAlbumRepository<int, Album> albumRepository) : IAlbumService
 {
-    readonly List<Album> albums = [
-            new Album{
-                Name = "Back in black",
-                Year = "1995",
-                Id = 1,
-                Genre = Genre.Rock,
-                // Artist = new Artist{
-                //     Name = "ACDC",
-                //     IsOnTour = true,
-                //     Label = "Sony",
-                //     Id = 1001,
-                // }
-            },
-            new Album{
-                Name = "Secod Song Name",
-                Year = "1990",
-                Id = 2,
-                Genre = Genre.Metal,
-                // Artist = new Artist{
-                //     Name = "Metallica",
-                //     IsOnTour = false,
-                //     Label = "Universal",
-                //     Id = 1002,
-                // }
-            },
-            new Album{
-                Name = "Third Song Name",
-                Year = "2005",
-                Id = 3,
-                Genre = Genre.Metal,
-                // Artist = new Artist{
-                //     Name = "Iron Maiden",
-                //     IsOnTour = true,
-                //     Label = "EMI",
-                //     Id = 1003,
-                // }
-            },
-            new Album{
-                Name = "Fourth song name",
-                Year = "2010",
-                Id = 4,
-                Genre = Genre.Metal,
-                // Artist = new Artist{
-                //     Name = "Megadeth",
-                //     IsOnTour = false,
-                //     Label = "Warner",
-                //     Id = 1004,
-                // }
-            },
-        ];
-    public async Task<List<Album>> AddAlbum()
+    private readonly IAlbumRepository<int, Album> _albumRepository = albumRepository;
+
+    public async Task<BaseMessage<Album>> AddAlbum(Album album)
     {
-        throw new NotImplementedException();
+        await _albumRepository.AddAsync(album);
+        return new BaseMessage<Album>()
+        {
+            Result = album,
+            StatusCode = HttpStatusCode.Created
+        };
     }
 
     public async Task<BaseMessage<List<Album>>> FindByArtist(string Artist)
     {
-        // var result = albums.FindAll(x => x.Artist.Name.Contains(Artist, StringComparison.CurrentCultureIgnoreCase)).ToList();
+        var result = await _albumRepository.FindByArtistAsync(Artist);
 
-        // if (result.Count == 0)
-        // {
-        //     return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with artist: {Artist}");
-        // }
-        // return BuilderResponse(result);
+        if (result.Count > 0)
+        {
+            return BuilderResponse(result);
+        }
 
-        return BuilderResponse(new List<Album>(), statusCode: HttpStatusCode.NotImplemented, message: $"Service disabled temporarily");
+        return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with artist: {Artist}");
     }
 
     public async Task<BaseMessage<List<Album>>> FindByGenre(string Genre)
     {
-        var result = albums.FindAll(x => x.Genre.ToString().Contains(Genre, StringComparison.CurrentCultureIgnoreCase)).ToList();
+        var result = await _albumRepository.FindByGenreAsync(Genre);
 
-        if (result.Count == 0)
+        if (result.Count > 0)
         {
-            return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with genre: {Genre}");
+            return BuilderResponse(result);
         }
 
-        return BuilderResponse(result);
 
+        return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with genre: {Genre}");
     }
 
-    public async Task<BaseMessage<List<Album>>> FindById(int Id)
+    public async Task<BaseMessage<Album>> FindById(int Id)
     {
-        var result = albums.Where(x => x.Id == Id).ToList();
+        var result = await _albumRepository.FindByIdAsync(Id);
 
-        if (result.Count == 0) {
-            return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not album found with Id: {Id}");
+        if (result != null)
+        {
+            return new BaseMessage<Album>()
+            {
+                Result = result
+            };
         }
 
-
-        return BuilderResponse(result);
+        return new BaseMessage<Album>()
+        {
+            StatusCode = HttpStatusCode.NotFound,
+            Message = $"Not album founded with id: {Id}",
+            Result = null!
+        };
     }
 
     public async Task<BaseMessage<List<Album>>> FindByName(string Name)
     {
-        var result = albums.FindAll(x => x.Name.ToLower().Contains(Name.ToLower())).ToList();
+        var result = await _albumRepository.FindByNameAsync(Name);
 
-        if (result.Count == 0)
+        if (result.Count > 0)
         {
-            return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with name: {Name}");
+            return BuilderResponse(result);
         }
 
-        return BuilderResponse(result);
-
+        return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with name: {Name}");
     }
 
     public async Task<BaseMessage<List<Album>>> FindByRangeOfYear(int StartYear, int EndYear)
     {
-        var result = albums.FindAll(x => int.TryParse(x.Year, out int year) && year >= StartYear && year <= EndYear).ToList();
+        var result = await _albumRepository.FindByRangeOfYearAsync(StartYear, EndYear);
 
-        if (result.Count == 0)
+        if (result.Count > 0)
         {
-            return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded between {StartYear} and {EndYear}");
+            return BuilderResponse(result);
         }
-
-        return BuilderResponse(result);
-
-
+       
+       return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with range of year: {StartYear} - {EndYear}");
     }
 
     public async Task<BaseMessage<List<Album>>> FindByYear(int Year)
     {
-        var result = albums.FindAll(x => x.Year == Year.ToString()).ToList();
+        var result = await _albumRepository.FindByRangeOfYearAsync(Year, Year);
 
-        if (result.Count == 0)
+        if (result.Count > 0)
         {
-            return BuilderResponse(result, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with year: {Year}");
+            return BuilderResponse(result);
         }
-    
-        return BuilderResponse(result);
+
+        return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: $"Not albums founded with year: {Year}");
 
     }
 
     public async Task<BaseMessage<List<Album>>> GetList()
     {
-        return BuilderResponse(albums);
+        var result = await _albumRepository.GetAllAsync();
+
+        if (result.Count > 0)
+        {        
+            return BuilderResponse(result);
+        }
+
+        return BuilderResponse(result!, statusCode: HttpStatusCode.NotFound, message: "Not albums founded");
     }
 
     private BaseMessage<List<Album>> BuilderResponse(List<Album> data, HttpStatusCode statusCode = HttpStatusCode.OK, string message = "Success")

--- a/TeslaACDC.Business/Services/ArtistService.cs
+++ b/TeslaACDC.Business/Services/ArtistService.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using TeslaACDC.Business.Interfaces;
+using TeslaACDC.Data;
+using TeslaACDC.Data.Interfaces;
+using TeslaACDC.Data.Models;
+using TeslaACDC.Data.Repository;
+
+namespace TeslaACDC.Business.Services;
+
+public class ArtistService(IArtistRepository<int, Artist> artistRepository) : IArtistService
+{
+    private readonly IArtistRepository<int, Artist> _artistRepository = artistRepository;
+
+
+    public async Task<BaseMessage<Artist>> Add(Artist artist)
+    {
+        await _artistRepository.AddAsync(artist);
+        return new BaseMessage<Artist>()
+        {
+            Result = artist,
+            StatusCode = HttpStatusCode.Created
+        };
+    }
+
+    public async Task<BaseMessage<Artist>> FindById(int id)
+    {
+        var foundArtist = await _artistRepository.FindByIdAsync(id);
+
+        if (foundArtist == null)
+        {
+            return new BaseMessage<Artist>()
+            {
+                Message = "Artist not found",
+                Result = null!,
+                StatusCode = HttpStatusCode.NotFound
+            };
+        }
+
+        return new BaseMessage<Artist>()
+        {
+            Result = foundArtist,
+        };
+    }
+
+    public async Task<BaseMessage<List<Artist>>> GetAll()
+    {
+        var artists = await _artistRepository.GetAllAsync();
+        return new BaseMessage<List<Artist>>()
+        {
+            Result = artists,
+        };
+    }
+
+    public async Task<BaseMessage<Artist>> Update(Artist artist)
+    {
+        var result = await _artistRepository.UpdateAsync(artist);
+
+        if (result != null)
+        {
+            return new BaseMessage<Artist>()
+            {
+                Result = artist
+            };
+        }
+
+        return new BaseMessage<Artist>()
+        {
+            Message = "Artist not found",
+            Result = null!,
+            StatusCode = HttpStatusCode.NotFound
+        };
+    }
+}

--- a/TeslaACDC.Data/Interfaces/IAlbumRepository.cs
+++ b/TeslaACDC.Data/Interfaces/IAlbumRepository.cs
@@ -1,0 +1,17 @@
+using TeslaACDC.Data.Models;
+
+namespace TeslaACDC.Data.Interfaces;
+
+public interface IAlbumRepository<TId, TEntity>
+where TId : struct
+where TEntity : BaseEntity<TId>
+{
+    Task AddAsync(TEntity album);
+    Task<Album> FindByIdAsync(TId id);
+    Task<List<Album>> GetAllAsync();
+    Task<List<Album>> FindByArtistAsync(string Artist);
+    Task<List<Album>> FindByGenreAsync(string Genre);
+    Task<List<Album>> FindByNameAsync(string Name);
+    Task<List<Album>> FindByRangeOfYearAsync(int StartYear, int EndYear);
+
+}

--- a/TeslaACDC.Data/Interfaces/IArtistRepository.cs
+++ b/TeslaACDC.Data/Interfaces/IArtistRepository.cs
@@ -1,0 +1,14 @@
+using TeslaACDC.Data.Models;
+
+namespace TeslaACDC.Data.Interfaces;
+
+public interface IArtistRepository<TId, TEntity>
+where TId : struct
+where TEntity : BaseEntity<TId>
+{
+    Task AddAsync(TEntity artist);
+    Task<TEntity> UpdateAsync(TEntity artist);
+    Task<TEntity> FindByIdAsync(TId id);
+    Task<List<TEntity>> GetAllAsync();
+
+}

--- a/TeslaACDC.Data/Models/Album.cs
+++ b/TeslaACDC.Data/Models/Album.cs
@@ -1,10 +1,17 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeslaACDC.Data.Models;
 
 public class Album : BaseEntity<int>
 {
     public string Name { get; set; } = string.Empty;
-    public string Year { get; set; } = string.Empty;
+    public int Year { get; set; } = int.MinValue;
     public Genre Genre { get; set; } = Genre.Unknown;
+
+    [ForeignKey("Artist")]
+    public int ArtistId { get; set; }
+    public virtual Artist? Artist { get; set; }
+
 }
 
 public enum Genre

--- a/TeslaACDC.Data/Models/Artist.cs
+++ b/TeslaACDC.Data/Models/Artist.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TeslaACDC.Data.Models;
 
 public class Artist : BaseEntity<int>

--- a/TeslaACDC.Data/Repository/AlbumRepository.cs
+++ b/TeslaACDC.Data/Repository/AlbumRepository.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using TeslaACDC.Data.Interfaces;
+using TeslaACDC.Data.Models;
+
+namespace TeslaACDC.Data.Repository;
+
+public class AlbumRepository<TId, TEntity> : IAlbumRepository<TId, TEntity>
+where TId : struct
+where TEntity : BaseEntity<TId>
+{
+
+    private readonly DatabaseContext _context;
+    internal DbSet<TEntity> dbSet;
+
+    public AlbumRepository(DatabaseContext context)
+    {
+        _context = context;
+        dbSet = _context.Set<TEntity>();
+    }
+
+    public async Task AddAsync(TEntity album)
+    {
+        await dbSet.AddAsync(album);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<List<Album>> FindByArtistAsync(string Artist)
+    {
+        return await _context.Albums.Include(x => x.Artist).Where(x => x.Artist!.Name.Equals(Artist)).ToListAsync();
+    }
+
+    public async Task<List<Album>> FindByGenreAsync(string Genre)
+    {
+        
+        return await _context.Albums.Include(x => x.Artist).Where(x => x.Genre.ToString().Contains(Genre)).ToListAsync();
+    }
+
+    public async Task<Album> FindByIdAsync(TId id)
+    {
+
+        #pragma warning disable CS8603 // Possible null reference return.
+
+        return await _context.Albums.Include(x => x.Artist).FirstOrDefaultAsync(x => x.Id.Equals(id) && x.Artist != null);
+
+    }
+
+    public async Task<List<Album>> FindByNameAsync(string Name)
+    {
+        return await _context.Albums.Include(x => x.Artist).Where(x => x.Name.ToLower().Contains(Name.ToLower())).ToListAsync();
+    }
+
+    public async Task<List<Album>> FindByRangeOfYearAsync(int StartYear, int EndYear)
+    {
+        return await _context.Albums.Include(x => x.Artist).Where(x => x.Year >= StartYear && x.Year <= EndYear).ToListAsync();
+    }
+
+    public async Task<List<Album>> GetAllAsync()
+    {
+        return await _context.Albums.Include(x => x.Artist).ToListAsync();
+    }
+}

--- a/TeslaACDC.Data/Repository/ArtistRepository.cs
+++ b/TeslaACDC.Data/Repository/ArtistRepository.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using TeslaACDC.Data.Interfaces;
+using TeslaACDC.Data.Models;
+
+namespace TeslaACDC.Data.Repository;
+
+public class ArtistRepository<TId, TEntity> : IArtistRepository<TId, TEntity>
+where TId : struct
+where TEntity : BaseEntity<TId>
+{
+
+    private readonly DatabaseContext _context;
+    internal DbSet<TEntity> dbSet;
+
+    public ArtistRepository(DatabaseContext context)
+    {
+        _context = context;
+        dbSet = _context.Set<TEntity>();
+    }
+
+    public async Task AddAsync(TEntity artist)
+    {
+        await dbSet.AddAsync(artist);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<TEntity> FindByIdAsync(TId id)
+    {
+        var result = await dbSet.FindAsync(id);
+        return result!;
+    }
+
+    public async Task<List<TEntity>> GetAllAsync()
+    {
+        return await dbSet.ToListAsync();
+    }
+
+    public async Task<TEntity> UpdateAsync(TEntity artist)
+    {
+        try
+        {
+            _context.Update(artist);
+            await _context.SaveChangesAsync();
+            return artist;
+        }
+        catch
+        {
+            return null!;
+        }
+    }
+
+}

--- a/TeslaACDC.Data/TeslaACDC.Data.csproj
+++ b/TeslaACDC.Data/TeslaACDC.Data.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/TeslaACDC.Testing/BrunoAPI/Album/create_album.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Album/create_album.bru
@@ -1,0 +1,20 @@
+meta {
+  name: create_album
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://localhost:5134/{{album_path}}/addAlbum
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Back In Black",
+    "Year": "1995",
+    "Genre": 1,
+    "ArtistId": 1
+  }
+}

--- a/TeslaACDC.Testing/BrunoAPI/Album/find/by_artist.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Album/find/by_artist.bru
@@ -5,11 +5,11 @@ meta {
 }
 
 get {
-  url: http://localhost:5134/{{album_path}}/findByArtist?artist=metallica
+  url: http://localhost:5134/{{album_path}}/findByArtist?artist=Shakira
   body: json
   auth: none
 }
 
 params:query {
-  artist: metallica
+  artist: Shakira
 }

--- a/TeslaACDC.Testing/BrunoAPI/Album/find/by_genre.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Album/find/by_genre.bru
@@ -5,11 +5,11 @@ meta {
 }
 
 get {
-  url: http://localhost:5134/{{album_path}}/findByGenre?genre=metal
+  url: http://localhost:5134/{{album_path}}/findByGenre?genre=Pop
   body: json
   auth: none
 }
 
 params:query {
-  genre: metal
+  genre: Pop
 }

--- a/TeslaACDC.Testing/BrunoAPI/Artist/add_artist.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Artist/add_artist.bru
@@ -1,0 +1,19 @@
+meta {
+  name: add_artist
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://localhost:5134/{{artist_path}}/addArtist
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "Name": "Romeo Santos",
+    "Label": "Sony Music",
+    "IsOnTour": true
+  }
+}

--- a/TeslaACDC.Testing/BrunoAPI/Artist/fin_by_id.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Artist/fin_by_id.bru
@@ -1,0 +1,11 @@
+meta {
+  name: fin_by_id
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:5134/{{artist_path}}/getartist/1
+  body: none
+  auth: none
+}

--- a/TeslaACDC.Testing/BrunoAPI/Artist/get_all_artists.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Artist/get_all_artists.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get_all_artists
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:5134/{{artist_path}}/getAllArtists
+  body: none
+  auth: none
+}

--- a/TeslaACDC.Testing/BrunoAPI/Artist/update_artist.bru
+++ b/TeslaACDC.Testing/BrunoAPI/Artist/update_artist.bru
@@ -1,0 +1,20 @@
+meta {
+  name: update_artist
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:5134/{{artist_path}}/updateArtist
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "Id": 3,
+    "Name": "Romeo Santos",
+    "Label": "Sony Music",
+    "IsOnTour": false
+  }
+}

--- a/TeslaACDC.Testing/BrunoAPI/environments/TeslaACDC.Enviroment.bru
+++ b/TeslaACDC.Testing/BrunoAPI/environments/TeslaACDC.Enviroment.bru
@@ -1,4 +1,5 @@
 vars {
   math_path: api/math
   album_path: api/album
+  artist_path: api/artist
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the TeslaACDC project, including the addition of new controllers, services, and repository interfaces for managing albums and artists. The most significant changes involve the creation of the `ArtistController`, the implementation of repository patterns for albums and artists, and updates to the `AlbumService` and `ArtistService` classes.

### New Features:
* Added `ArtistController` to handle artist-related API requests.
* Added `IArtistService` interface and `ArtistService` class to manage artist operations. [[1]](diffhunk://#diff-19024381b83d8d1962dacddfd26203d4093bddbd5909814b297d3fd64ad3f582R1-R13) [[2]](diffhunk://#diff-d101c180f6609c9349eb3563d4faab0c5b75d1c3ce39b3d3dedbbf1ea9a8adc5R1-R73)
* Added repository interfaces `IAlbumRepository` and `IArtistRepository` for data access. [[1]](diffhunk://#diff-8d9ad6b8e359df994f789cbfbc5e0f0c50729a3feda1d39288cf7da31edc067bR1-R17) [[2]](diffhunk://#diff-15ea2b74eeb86e97d2d970ee104e18f4b121f0e186ff3fa94a097d33268d2d78R1-R14)
* Implemented `AlbumRepository` and `ArtistRepository` classes for album and artist data management. [[1]](diffhunk://#diff-b08df786e66d4cce184f88515249b511893ddd98a16c0c42ced23f52ef68c895R1-R62) [[2]](diffhunk://#diff-fd828823635191add798cb9879e3b40e0a87471b367917743372013cc41e6c49R1-R52)

### Updates and Improvements:
* Modified `AlbumService` to use `IAlbumRepository` for data operations, replacing the in-memory album list.
* Added dependency injection for the new services and repositories in `Program.cs`.
* Updated `Album` and `Artist` models to include foreign key relationships and other necessary attributes. [[1]](diffhunk://#diff-43c6f7219e0ac3d4bcc41ca370f296177881bc40ec57cc6976333299317625e9R1-R14) [[2]](diffhunk://#diff-ed70b1436f5079483b0b2719b599875c699b93bd718b54cbeb6e151c56355bf7R1-R2)

### Testing:
* Added new test scenarios for creating albums and finding albums by artist and genre in the `BrunoAPI` test suite. [[1]](diffhunk://#diff-848346b603e63f4b27cb941c0e230fc87f41c6e339b888448d449c86bdd185eaR1-R20) [[2]](diffhunk://#diff-90ec1546c55c7fc51592ae77724f052357c86be04ffd61f880c7d6d5ac6a86b9L8-R14) [[3]](diffhunk://#diff-46c25b71b8b935275eb7ed995e96808461889f265e1dffcb6164b1af28574d19L8-R14)